### PR TITLE
Minimize npm-install footprint

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-npm-debug.log
-node_modules
-example
-docs
-.idea
-
-
-# don't ignore .npmignore files
-!.npmignore

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     }
   ],
   "main": "lib/virtual-dom-component",
+  "files": [
+    "lib"
+  ],
   "engines": {
       "node": ">= 0.10.26",
       "npm": ">=1.4.3"


### PR DESCRIPTION
Simpler than having `.npmignore` and ensures the installation is as simple as necessary.
